### PR TITLE
JEI reload performance improvement

### DIFF
--- a/src/main/java/io/github/noeppi_noeppi/mods/bongo/task/TaskTypeEntity.java
+++ b/src/main/java/io/github/noeppi_noeppi/mods/bongo/task/TaskTypeEntity.java
@@ -1,20 +1,17 @@
 package io.github.noeppi_noeppi.mods.bongo.task;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
-import io.github.noeppi_noeppi.mods.bongo.render.RenderHelper;
 import io.github.noeppi_noeppi.mods.bongo.util.RenderEntityCache;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.AbstractGui;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.entity.EntityRenderer;
-import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.item.SpawnEggItem;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.server.MinecraftServer;
@@ -64,7 +61,6 @@ public class TaskTypeEntity implements TaskType<EntityType<?>> {
             Entity entity = RenderEntityCache.getRenderEntity(mc, content);
             AxisAlignedBB bb = entity.getRenderBoundingBox();
             float scale = (float) Math.min(Math.min(8d / bb.getXSize(), 16d / bb.getYSize()), 8d / bb.getZSize());
-            System.out.println(content + ": " + scale + "  [" + bb + "]");
             matrixStack.translate(8, 16, 100);
             matrixStack.scale(scale, scale, scale);
             matrixStack.rotate(Vector3f.ZP.rotationDegrees(180));

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,3 +1,4 @@
 public net.minecraft.command.impl.AdvancementCommand$Action
 public net.minecraft.command.impl.AdvancementCommand.Action func_198180_a(Lnet/minecraft/entity/player/ServerPlayerEntity;Ljava/lang/Iterable;)I #applyToAdvancements
 public net.minecraft.advancements.DisplayInfo field_192301_b #icon  Yep because the getter is client only but not the field and we need it on server. MC is weird.
+public net.minecraft.resources.SimpleReloadableResourceManager field_199015_d # reloadListeners to get the JEI reloader instance


### PR DESCRIPTION
This does not fire a full recipe reload event like before. Rather it checks the registered reload listeners, selects the ones of type mezz.jei.startup.ClientLifecycleHandler$JeiReloadListener and fires those specifically. This procedure drastically reduces the client lag on /bingo start or stop. Also fixed the Sys out in TaskTypeEntity