### PR TITLE
fix skyblock builder generating spawn island in normal worlds

### DIFF
--- a/src/main/java/io/github/noeppi_noeppi/mods/bongo/compat/SkyblockIntegration.java
+++ b/src/main/java/io/github/noeppi_noeppi/mods/bongo/compat/SkyblockIntegration.java
@@ -1,6 +1,7 @@
 package io.github.noeppi_noeppi.mods.bongo.compat;
 
 import de.melanx.skyblockbuilder.events.*;
+import de.melanx.skyblockbuilder.util.WorldTypeUtil;
 import de.melanx.skyblockbuilder.util.WorldUtil;
 import de.melanx.skyblockbuilder.world.data.SkyblockSavedData;
 import io.github.noeppi_noeppi.mods.bongo.Bongo;
@@ -33,6 +34,10 @@ public class SkyblockIntegration {
         
         @SubscribeEvent
         public void onStop(BongoStopEvent.World event) {
+            if (!WorldUtil.isSkyblock(event.getWorld())) {
+                return;
+            }
+
             // Delete all skyblock teams that were created.
             SkyblockSavedData data = SkyblockSavedData.get(event.getWorld());
             de.melanx.skyblockbuilder.util.Team spawn = data.getSpawn();

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -37,7 +37,7 @@ It's a bingo mod.
 [[dependencies.bongo]]
     modId="skyblockbuilder"
     mandatory=false
-    versionRange="[1.1.1,)"
+    versionRange="[1.1.1,1.1.2]"
     ordering="NONE"
     side="BOTH"
 


### PR DESCRIPTION
Setting max skyblock builder version to 1.1.2 because in 1.1.3 there will be added a few more events which should be canceled. 
Unfortunally, it doesn't stop launching the game with a too high version. This only happens if mandatory is set to true.