### PR TITLE
Fix bookmarklist not updating with newer JEI version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     implementation fg.deobf("io.github.noeppi_noeppi.mods:LibX:1.18.1-3.1.0")
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.18-5.0.2.4:api")
-    runtimeOnly fg.deobf("mezz.jei:jei-1.18.1:9.1.1.48")
+    runtimeOnly fg.deobf("mezz.jei:jei-1.18.1:9.2.3.77")
     runtimeOnly fg.deobf("de.melanx:JustEnoughAdvancements:1.18.1-3.1.0")
     compileOnly fg.deobf("de.melanx:SkyblockBuilder:1.18.1-3.0.3")
     implementation fg.deobf("io.github.noeppi_noeppi.mods:MineMention:1.18.1-1.2.0")

--- a/src/main/java/io/github/noeppi_noeppi/mods/bongo/compat/JeiIntegration.java
+++ b/src/main/java/io/github/noeppi_noeppi/mods/bongo/compat/JeiIntegration.java
@@ -69,10 +69,6 @@ public class JeiIntegration {
         objectListField.setAccessible(true);
         List<?> objectList = (List<?>) objectListField.get(bookmarkList);
         objectList.clear();
-        Field ingredientListField = bookmarkListClass.getDeclaredField("ingredientListElements");
-        ingredientListField.setAccessible(true);
-        List<?> ingredientList = (List<?>) ingredientListField.get(bookmarkList);
-        ingredientList.clear();
         forceBookmarkUpdate(bookmarkList);
     }
 
@@ -97,7 +93,7 @@ public class JeiIntegration {
         Field ingredientManagerField = bookmarkListClass.getDeclaredField("ingredientManager");
         ingredientManagerField.setAccessible(true);
         Object ingredientManager = ingredientManagerField.get(bookmarkList);
-        Field ingredientListField = bookmarkListClass.getDeclaredField("ingredientListElements");
+        Field ingredientListField = bookmarkListClass.getDeclaredField("list");
         ingredientListField.setAccessible(true);
         Object ingredientList = ingredientListField.get(bookmarkList);
         Class<?> bookmarkConfigClass = Class.forName("mezz.jei.config.BookmarkConfig");

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -48,3 +48,10 @@ It's a bingo mod.
     versionRange="[1.18-1.1.0,)"
     ordering="NONE"
     side="BOTH"
+
+[[dependencies.bongo]]
+    modId="jei"
+    mandatory=false
+    versionRange="[9.2.3.77,)"
+    ordering="NONE"
+    side="BOTH"


### PR DESCRIPTION
JEI removed a field in this commit: https://github.com/mezz/JustEnoughItems/commit/dcdee9f9b712cd547fc1885c7a32b4607f95c3cd
This PR fixes the compat between JEI and Bongo, additionally adds a minimum required version for JEI, not mandatory.

closes #40