### PR TITLE
add a leaderboard when finished the game

### DIFF
--- a/custom-bingos.md
+++ b/custom-bingos.md
@@ -33,7 +33,9 @@ Your settings should be defined in a file in `data/<datapack-id>/bingo_settings/
   ],
   "teleporter": "bongo.no_tp",
   "teleportRadius": 500,
-  "maxTime": -1
+  "maxTime": -1,
+  "lockout": false,
+  "leaderboard": false
 }
 ```
 
@@ -141,6 +143,10 @@ bongo.skyblock   (Only when SkyBlockBuilder is present) Teleports each team to a
 ### lockout
 
 Setting `lockout` to true will lock a task for all other teams as soon as one teams completes a task. Default is `false`.
+
+### leaderboard
+
+Setting `leaderboard` to true will show a list of teams which team had which amount of tasks completed. Useful for [`winAll`](#win-condition) condition. Default is `false`.
 
 ## Tasks
 

--- a/src/main/java/io/github/noeppi_noeppi/mods/bongo/data/GameSettings.java
+++ b/src/main/java/io/github/noeppi_noeppi/mods/bongo/data/GameSettings.java
@@ -49,6 +49,7 @@ public class GameSettings {
     private final PlayerTeleporter teleporter;
     public final int maxTime;
     public final boolean lockout;
+    public final boolean leaderboard;
 
     public GameSettings(ResourceLocation id, CompoundTag nbt) {
         this.id = id;
@@ -182,6 +183,8 @@ public class GameSettings {
             this.lockout = false;
         }
 
+        this.leaderboard = nbt.getBoolean("leaderboard");
+
         this.nbt = new CompoundTag();
         this.nbt.putString("winCondition", winCondition.id);
         this.nbt.putBoolean("invulnerable", invulnerable);
@@ -207,6 +210,7 @@ public class GameSettings {
         this.nbt.putString("teleporter", this.teleporter.getId());
         this.nbt.putInt("maxTime", this.maxTime);
         this.nbt.putBoolean("lockout", this.lockout);
+        this.nbt.putBoolean("leaderboard", this.leaderboard);
 
         // the default settings and already merged settings should still get the normal nbt for merging.
         if (DEFAULT_ID.equals(id) || CUSTOM_ID.equals(id)) {

--- a/src/main/resources/assets/bongo/lang/de_de.json
+++ b/src/main/resources/assets/bongo/lang/de_de.json
@@ -57,6 +57,7 @@
   "bongo.task.stat.name": "Statistik",
   "bongo.task.tag.empty": "Fehler: Leeres Tag",
   "bongo.task_locked.death": "%s ist gestorben. Eine Aufgabe wurde gesperrt.",
+  "bongo.tasks": "Aufgabe(n)",
   "bongo.team.black": "Team Schwarz",
   "bongo.team.blue": "Team Blau",
   "bongo.team.brown": "Team Braun",

--- a/src/main/resources/assets/bongo/lang/en_us.json
+++ b/src/main/resources/assets/bongo/lang/en_us.json
@@ -57,6 +57,7 @@
   "bongo.task.stat.name": "Statistic",
   "bongo.task.tag.empty": "Error: Empty Tag",
   "bongo.task_locked.death": "%s died. A task has been locked.",
+  "bongo.tasks": "Task(s)",
   "bongo.team.black": "Team Black",
   "bongo.team.blue": "Team Blue",
   "bongo.team.brown": "Team Brown",


### PR DESCRIPTION
This PR adds a kind of leaderboard once a team won the game. This was a highly requested feature for this mod.
It respects the previous places to give a proper result. 
Example:
1. Team Black - 5 Tasks
2. Team Yellow - 4 Tasks
2. Team Magenta - 4 Tasks
4. Team White - 2 Tasks

As you can see, there is two times place 2 and no place 3 because one of the two place 2 teams blocks place 3. I hope you understand the intention.

And yes, I tested it with my friends:
![](https://cdn.discordapp.com/attachments/519945279869419526/934225756853264384/unknown.png)
